### PR TITLE
Fix and improve elf process

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Windows:
 
 ```bash
 # 写入多个文件到不同地址
-sftool -c SF32LB52 -p /dev/ttyUSB0 write_flash bootloader.bin@0x1000 app.bin@0x12010000 ftab.bin@0x12000000
+sftool -c SF32LB52 -p /dev/ttyUSB0 write_flash bootloader.bin@0x12010000 app.bin@0x12020000 ftab.bin@0x12000000
 # 其它同上
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -66,7 +66,7 @@ sftool [OPTIONS] COMMAND [COMMAND OPTIONS]
 # Linux/Mac
 sftool -c SF32LB52 -p /dev/ttyUSB0 write_flash [OPTIONS] <FILE@ADDRESS>...
 # Windows
-sftool -c SF32LB52 -p COM9 write_flash [选项] <文件@地址>...
+sftool -c SF32LB52 -p COM9 write_flash [OPTIONS] <FILE@ADDRESS>...
 ```
 
 #### Write Flash Options
@@ -98,7 +98,7 @@ Windows:
 
 ```bash
 # Write multiple files to different addresses
-sftool -c SF32LB52 -p COM7 write_flash bootloader.bin@0x1000 app.bin@0x12010000 ftab.bin@0x12000000
+sftool -c SF32LB52 -p COM7 write_flash bootloader.bin@0x12010000 app.bin@0x12020000 ftab.bin@0x12000000
 # Other as above
 ```
 

--- a/sftool-lib/src/lib.rs
+++ b/sftool-lib/src/lib.rs
@@ -231,7 +231,7 @@ impl SifliTool {
         std::thread::sleep(Duration::from_millis(500));
 
         if !base_param.quiet {
-            spinner.finish_with_message("Connected success!");
+            spinner.finish_with_message("Successfully connected!");
         }
         Ok(())
     }


### PR DESCRIPTION
修复：
1.原本的elf_to_bin中，不知道为什么将size加在一起作为base_address，地址是错误的，无法下载。
2.使用同一个tempfile可能导致一些问题，比如crc计算。
3.原本的处理并未对齐Sector(elf中通常是好几块内容)，下载时会出现：
```
burn_erase_write 0x120201cc 0x0000df50
addr:0x120201cc, size:0x1000000 sector:0x1000 page:0x0 id:0x182085
base_addr not aligned in sector
```
但也不能直接填充，因为这几块事实上还是连在一起的。
（也可能不连接，如果空隙超过一个Sector的大小，就会自动分为多个bin文件）

功能：
根据MAGIC识别没有扩展名的elf（rust编译的elf固件通常没有拓展名）